### PR TITLE
Sync user groups when position or application state changes

### DIFF
--- a/src/involvement/models/application.py
+++ b/src/involvement/models/application.py
@@ -92,6 +92,11 @@ class Application(ClusterableModel):
 
 
 @receiver(post_save, sender=Application,
+        dispatch_uid='application_sync_user_groups')
+def sync_user_groups(sender, instance, update_fields, **kwargs):
+    instance.applicant.sync_user_groups()
+
+@receiver(post_save, sender=Application,
           dispatch_uid='application_check_mandate_history')
 def check_mandate_history(sender, instance, **kwargs):
     MandateHistory = apps.get_model('involvement', 'MandateHistory')

--- a/src/involvement/models/position.py
+++ b/src/involvement/models/position.py
@@ -131,3 +131,9 @@ def position_check_contact_card(sender, instance, **kwargs):
             removedCards += 1
             if removedCards == maxCardsToRemove:
                 break
+
+@receiver(post_save, sender=Position,
+          dispatch_uid='position_sync_user_groups')
+def sync_user_groups(sender, instance, **kwargs):
+    for appl in instance.appointed_applications.all():
+        appl.applicant.sync_user_groups()

--- a/src/members/models/member.py
+++ b/src/members/models/member.py
@@ -238,3 +238,19 @@ class Member(SimpleEmailConfirmationUserMixin, AbstractUser):
             pass
 
         return None
+
+    def sync_user_groups(self):
+        current_groups = self.groups.all()
+        wanted_groups = list(map(lambda role: role.group, self.roles.filter(
+            positions__applications__removed=False
+        ).all()))
+
+        # Remove unavailable groups
+        for group in current_groups:
+            if group not in wanted_groups:
+                group.user_set.remove(self)
+
+        # Add missing groups
+        for group in wanted_groups:
+            if (group not in current_groups):
+                group.user_set.add(self)


### PR DESCRIPTION
Det finns ett cron-jobb som ska göra den här synkningen var 6e timme som är kvar.
Nu sätts iaf rättigheterna direkt när man ändrar status på application eller ändrar slutdatum på en post.

> När vi tillsätter en person till en roll med en behörighetsgrupp så får den personen som tillsätts inte behörigheterna automatiskt utan vi måste manuellt gå in på den personen och lägga till den i rätt behörighetsgrupp.
> 
> Vi vill att detta ska göras automatiskt som det står i specen. I specen står det att rollbehörigheten ska föras över till den som är innehavare av posten.